### PR TITLE
Removing extra libicu exports in CMakeLists.txt (Linux)

### DIFF
--- a/build/cmake/terrame/CMakeLists.txt
+++ b/build/cmake/terrame/CMakeLists.txt
@@ -654,7 +654,9 @@ else(UNIX)
 		${Qt5_DIR}/../../libQt5Svg.so*
 		${Qt5_DIR}/../../libQt5OpenGL.so*
 		${Qt5_DIR}/../../libQt5DBus.so*
-		${Qt5_DIR}/../../libicu*
+		${Qt5_DIR}/../../libicui18n.so*
+		${Qt5_DIR}/../../libicuuc.so*
+		${Qt5_DIR}/../../libicudata.so*
 		${Qt5_DIR}/../../libkmldom*so*
 		${Qt5_DIR}/../../libkmlengine*so*
 		${Qt5_DIR}/../../libkmlbase*so*


### PR DESCRIPTION
- [x] #1573 - Only the following libraries are required by Qt5 in TerraME installation: 
  * libicui18n.so*
  * libicuuc.so*
  * libicudata.so*

The command used to identify: 
```bash
find PATH_TO_TERRAME_BIN -name *.so -exec ldd {} \; | grep libicu*
```