### PR TITLE
Moving Jenkins scripts to TerraME

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,18 @@
+### Jenkins
+
+This folder describes the config and scripts files used for Jenkins execution.
+
+### Structure 
+
+We made a individual folder set for each operational system described above.
+
+- **all** - Defines a common files used among operational systems. (`config.lua` and `test.lua`);
+- **linux** - Defines scripts files for Linux environment. (`ubuntu-14.04`);
+- **win** - Defines scripts files for Windows environment;
+- **mac** - Defines scripts files for Mac OSX environment. (`mac-el-capitan`);
+
+Feel free to edit them and Jenkins will execute when a GitHub Pull Request triggered or even daily builds.
+
+### Tips
+
+If you would like to change TerraLib branch, look for `_TERRALIB_BRANCH` in `terrame-terralib*.sh|bat`.

--- a/jenkins/all/config.lua
+++ b/jenkins/all/config.lua
@@ -1,0 +1,2 @@
+user = "postgres"
+password = "postgres"

--- a/jenkins/all/test.lua
+++ b/jenkins/all/test.lua
@@ -1,3 +1,2 @@
-lines = true
 time = true
 examples = true

--- a/jenkins/all/test.lua
+++ b/jenkins/all/test.lua
@@ -1,0 +1,3 @@
+lines = true
+time = true
+examples = true

--- a/jenkins/all/test.lua
+++ b/jenkins/all/test.lua
@@ -1,2 +1,3 @@
 time = true
 examples = true
+lines = true

--- a/jenkins/linux/terrame-3rdparty-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-3rdparty-linux-ubuntu-14.04.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs TerraME TerraLib compilation on Linux Ubuntu 14.04 system
+#
+
+if [ -z "$_TERRALIB_TARGET_3RDPARTY_DIR" ]; then
+  export _TERRALIB_TARGET_3RDPARTY_DIR="$HOME/MyDevel/terrame/daily/terralib/3rdparty/5.2"
+fi
+
+if [ -z "$_TERRAME_TARGET_3RDPARTY_DIR" ]; then
+  export _TERRAME_TARGET_3RDPARTY_DIR="$HOME/MyDevel/terrame/daily/terrame/3rdparty"
+fi
+
+if [ -z "$_TERRALIB_3RDPARTY_NAME" ]; then
+  export _TERRALIB_3RDPARTY_NAME="terralib-3rdparty-linux-ubuntu-14.04.tar.gz"
+fi
+
+# Defines TerraLib script version to prepare dependencies
+_TERRALIB_BRANCH="release-5.2"
+
+if [ -z "$_TERRALIB_TARGET_URL" ]; then
+  export _TERRALIB_TARGET_URL="http://www.dpi.inpe.br/terralib5-devel/3rdparty/src/$_TERRALIB_3RDPARTY_NAME"
+fi
+
+#
+# Valid parameter val or abort script
+#
+function valid_operation()
+{
+  if [ $1 -ne 0 ]; then
+    echo $2
+    echo ""
+    exit $1
+  else
+    echo "done."
+  fi
+}
+
+
+echo ""
+echo "#### TerraME Dependencies Compilation on Linux Ubuntu 14.04 ####"
+echo ""
+
+echo -ne "Cleaning up old builds ... "
+rm -rf $_TERRALIB_TARGET_3RDPARTY_DIR $_TERRAME_TARGET_3RDPARTY_DIR
+mkdir -p $_TERRALIB_TARGET_3RDPARTY_DIR $_TERRAME_TARGET_3RDPARTY_DIR
+cd $_TERRALIB_TARGET_3RDPARTY_DIR
+valid_operation $? "Error: Could not enter $_TERRALIB_TARGET_3RDPARTY_DIR"
+
+echo ""
+
+echo -ne "Downloading TerraLib 3rdparty ... "
+curl -O $_TERRALIB_TARGET_URL --silent
+valid_operation $? "Error. Check $_TERRALIB_TARGET_URL"
+
+echo -ne "Downloading TerraLib ... "
+git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git --quiet
+valid_operation $? "Error. Could not clone TerraLib $_TERRALIB_BRANCH"
+
+echo -ne "Downloading TerraME ... "
+git clone https://github.com/TerraME/terrame.git terrame --quiet
+valid_operation $? "Error: Could not download TerraME"
+
+# Configuring TerraLib 3rdparty compilation
+cp terralib/install/install-3rdparty-linux-ubuntu-14.04.sh .
+
+# Configuring TerraME dependencies compilation
+cp terrame/build/scripts/linux/terrame-deps-conf.sh $_TERRAME_TARGET_3RDPARTY_DIR
+
+TERRALIB_DEPENDENCIES_DIR="$_TERRALIB_TARGET_3RDPARTY_DIR" ./install-3rdparty-linux-ubuntu-14.04.sh
+valid_operation $? "Error: Could not finish TerraLib 3rdparty compilation."
+
+echo ""
+echo ""
+
+cd $_TERRAME_TARGET_3RDPARTY_DIR
+
+echo -ne "Downloading Protobuf ... "
+curl -L -O https://github.com/google/protobuf/releases/download/v3.1.0/protobuf-cpp-3.1.0.tar.gz --silent
+valid_operation $? "Error. Could not download 3rdparty"
+
+echo -ne "Downloading Luacheck ... "
+curl -L -O https://github.com/mpeterv/luacheck/archive/0.17.0.tar.gz --silent
+valid_operation $? "Error: Could not download LuaCheck"
+
+echo ""
+echo -ne "Preparing to compilation ... "
+tar zxf protobuf-cpp-3.1.0.tar.gz
+valid_operation $? "Error: Could not extract protobuff"
+mv protobuf-3.1.0 protobuf
+valid_operation $? "Error: Could find 'protobuf' folder inside compressed protobuf"  
+tar zxf 0.17.0.tar.gz
+valid_operation $? "Error: Could not extract Luacheck" 
+mv luacheck* luacheck
+valid_operation $? "Error: Could find luacheck inside luacheck compressed file" 
+
+echo -ne "Compiling TerraME dependencies ... "
+./terrame-deps-conf.sh
+valid_operation $? "Error: Could not finish TerraME 3rdparty compilation."
+
+echo ""
+echo "Finished"
+echo ""

--- a/jenkins/linux/terrame-build-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-build-linux-ubuntu-14.04.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs TerraME compilation. It does not create installer or even build as bundle.
+#
+## USAGE:
+## ./terrame-build-linux-ubuntu-14.04.sh
+##
+#
+
+cd $_TERRAME_BUILD_BASE/solution
+ 
+# Turning OFF installer flags
+export _TERRAME_CREATE_INSTALLER="OFF"
+export _TERRAME_BUILD_AS_BUNDLE="OFF"
+
+# Executing TerraME build script
+./terrame-conf.sh
+
+exit $?

--- a/jenkins/linux/terrame-code-analysis-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-code-analysis-linux-ubuntu-14.04.sh
@@ -46,7 +46,6 @@ terrame -version
 # Extra commands if package is terralib
 if [ "$1" != "" ] && [ "$1" != "base" ]; then
   TERRAME_COMMANDS="-package $1"
-  # terrame -color -package $PACKAGE -uninstall
 fi
 
 # Execute TerraME doc generation

--- a/jenkins/linux/terrame-code-analysis-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-code-analysis-linux-ubuntu-14.04.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -l
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME code analysis of any package. For TerraME purporses, "base" and "terralib" internal packages. 
+## It may be useful for TerraME external packages.
+#
+## USAGE:
+## ./terrame-code-analysis-linux-ubuntu-14.04.sh PACKAGE_NAME
+#
+## WHERE:
+## PACKAGE_NAME - Represents a name of TerraME package to execute
+#
+
+# Exporting terrame vars
+export TME_PATH="$_TERRAME_INSTALL_PATH/bin"
+export PATH=$PATH:$TME_PATH
+export LD_LIBRARY_PATH=$TME_PATH
+
+cd $_TERRAME_TEST_DIR
+
+# TerraME command arguments. Used for packages like "terralib", "sci", "calibration" etc.
+TERRAME_COMMANDS=""
+terrame -version
+# Extra commands if package is terralib
+if [ "$1" != "" ] && [ "$1" != "base" ]; then
+  TERRAME_COMMANDS="-package $1"
+  # terrame -color -package $PACKAGE -uninstall
+fi
+
+# Execute TerraME doc generation
+terrame -color $TERRAME_COMMANDS -check
+
+exit $?

--- a/jenkins/linux/terrame-doc-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-doc-linux-ubuntu-14.04.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -l
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME doc generation of any package. For TerraME purporses, "base" and "terralib" internal packages. 
+## It may be useful for TerraME external packages.
+#
+## USAGE:
+## ./terrame-doc-linux-ubuntu-14.04.sh PACKAGE_NAME
+#
+## WHERE:
+## PACKAGE_NAME - Represents a name of TerraME package to execute
+##
+#
+
+# Exporting context
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+export LD_LIBRARY_PATH=$TME_PATH
+
+cd $_TERRAME_TEST_DIR
+
+TERRAME_COMMANDS=""
+terrame -version
+if [ "$1" != "" ] && [ "$1" != "base" ]; then
+  TERRAME_COMMANDS="-package $1"
+  terrame -color $TERRAME_COMMANDS -projects 2>/dev/null
+fi
+
+# Execute TerraME doc generation
+terrame -color $TERRAME_COMMANDS -doc 2> /dev/null
+# Retrieve TerraME exit code
+exit $?

--- a/jenkins/linux/terrame-installer-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-installer-linux-ubuntu-14.04.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME Installer generation
+#
+## USAGE:
+## ./terrame-installer-linux-ubuntu-14.04.sh
+#
+
+export _TERRAME_CREATE_INSTALLER="ON"
+export _TERRAME_BUILD_AS_BUNDLE="OFF"
+
+cd $_TERRAME_OUT_DIR/..
+
+# Copying Generated documentation to Git directory
+cp -rap $_TERRAME_INSTALL_PATH/bin/packages/base/doc $_TERRAME_GIT_DIR/packages/base/doc
+cp -rap $_TERRAME_INSTALL_PATH/bin/packages/terralib/doc $_TERRAME_GIT_DIR/packages/terralib/doc
+
+# Removing old builds
+rm -rf $_TERRAME_INSTALL_PATH $_TERRAME_OUT_DIR
+
+# Executing TerraME build script
+./terrame-conf.sh
+
+cd $_TERRAME_OUT_DIR
+
+cpack -G TGZ -C Release --config ./CPackConfig.cmake
+
+exit $?

--- a/jenkins/linux/terrame-repository-test-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-repository-test-linux-ubuntu-14.04.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME Repository Tests.
+#
+## USAGE:
+## ./terrame-repository-test-linux-ubuntu-14.04.sh
+#
+
+export TME_PATH="$_TERRAME_INSTALL_PATH/bin"
+export PATH=$PATH:$TME_PATH
+export LD_LIBRARY_PATH=$TME_PATH
+
+cd $_TERRAME_REPOSITORY_DIR
+
+terrame -version
+terrame -color test.lua 2> /dev/null
+
+RESULT=$?
+
+tar -czf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/linux/terrame-repository-test-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-repository-test-linux-ubuntu-14.04.sh
@@ -40,7 +40,7 @@ terrame -color test.lua 2> /dev/null
 
 RESULT=$?
 
-tar -czf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+tar -czf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
 rm -rf .terrame*
 
 exit $RESULT

--- a/jenkins/linux/terrame-syntaxcheck-cpp-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-syntaxcheck-cpp-linux-ubuntu-14.04.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It executes a static code inspection for TerraME C++ files
+##
+#
+## VARIABLES:
+## _TERRAME_GIT_DIR - Path to TerraME clone
+#
+## USAGE:
+## ./terrame-syntaxcheck-cpp-linux-ubuntu-14.04.sh
+##
+#
+
+python $HOME/Programs/cpplint/cpplint.py --filter=-whitespace/comments,-whitespace/tab,-whitespace/indent,-whitespace/braces,-build/namespaces,-build/header_guard,-whitespace/line_length,-readability/casting,-runtime/references,-build/include,-runtime/printf,-whitespace/newline,-runtime/explicit,-whitespace/parens,-runtime/int,-runtime/threadsafe --extensions=c,h,cpp `find "$_TERRAME_GIT_DIR/src/" -name *.h -o -name *.c*`
+
+exit $?

--- a/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
@@ -56,12 +56,12 @@ if [ ! -z "$ghprbActualCommit" ]; then
   cd $_TERRAME_GIT_DIR
   git init
   git config remote.origin.url https://github.com/terrame/terrame.git
-  git fetch --tags --progress https://github.com/TerraME/terrame.git +refs/pull/*:refs/remotes/origin/pr/* --quiet
-  git checkout -f $ghprbActualCommit --quiet
+  git fetch --tags --progress https://github.com/TerraME/terrame.git +refs/pull/*:refs/remotes/origin/pr/* --quiet > /dev/null
+  git checkout -f $ghprbActualCommit --quiet > /dev/null
   cd -
 else
   # Just clone
-  git clone https://github.com/terrame/terrame.git -b jenkins $_TERRAME_GIT_DIR --quiet
+  git clone https://github.com/terrame/terrame.git $_TERRAME_GIT_DIR --quiet
 fi
 
 echo "### TerraLib ###"

--- a/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It prepares a entire TerraME build process. Firstly, it prepares environment, cloning both TerraME and TerraLib.
+## After that, It copies required scripts to respective folders. Once done, it compiles TerraLib.
+#
+## VARIABLES:
+## _TERRAME_GIT_DIR - Path to TerraME clone
+## _TERRALIB_GIT_DIR - Path to TerraLib clone
+## _TERRAME_DEPENDS_DIR - Path to TerraME dependencies
+## _TERRALIB_INSTALL_PATH - Path to TerraLib Installation
+## _TERRALIB_3RDPARTY_DIR - Path to TerraLib dependencies
+## _TERRAME_TEST_DIR - Path where TerraME tests will execute.
+## _TERRAME_REPOSITORY_DIR - Path where TerraME repository test will execute
+## _TERRAME_EXECUTION_DIR - Path where TerraME test execution will run
+## ghprbActualCommit (Injected by Jenkins on GitHub Pull Requests) (Optional) - Git Commit hash
+## sha1 (Injected by Jenkins on GitHub Pull Requests) (Optional) - Represents refspec Pull Request (origin/PR_ID/head)
+#
+## USAGE:
+## ./terrame-terralib-build-linux-ubuntu-14.04.sh
+##
+#
+
+# Constants
+_TERRALIB_BRANCH=release-5.2
+
+# Removing TerraLib Mod Binding Lua in order to re-generate folder if there is
+rm -rf $_TERRALIB_OUT_DIR/terralib_mod_binding_lua $_TERRALIB_INSTALL_PATH $_TERRAME_GIT_DIR $_TERRALIB_GIT_DIR $_TERRAME_BUILD_BASE/solution
+rm -rf $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR
+
+echo "### TerraME ###"
+# Identifying when PR to clone respective changes
+if [ ! -z "$ghprbActualCommit" ]; then
+  mkdir -p $_TERRAME_GIT_DIR
+  cd $_TERRAME_GIT_DIR
+  git init
+  git config remote.origin.url https://github.com/terrame/terrame.git
+  git fetch --tags --progress https://github.com/TerraME/terrame.git +refs/pull/*:refs/remotes/origin/pr/* 2> /dev/null
+  git checkout -f $ghprbActualCommit
+  cd -
+else
+  # Just clone
+  git clone https://github.com/raphaelrpl/terrame.git -b jenkins $_TERRAME_GIT_DIR
+fi
+
+echo "### TerraLib ###"
+git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git $_TERRALIB_GIT_DIR
+
+# Creating TerraME Test folders and TerraLib solution
+mkdir $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR $_TERRALIB_BUILD_BASE/solution $_TERRAME_BUILD_BASE/solution
+
+cd $_TERRALIB_BUILD_BASE/solution
+
+# Copying TerraME Git Repository to Test Repository Folder
+cp -r $_TERRAME_GIT_DIR/repository/* $_TERRAME_REPOSITORY_DIR
+# Copying TerraME Git Test Execution to Test Execution Folder
+cp -r $_TERRAME_GIT_DIR/test/* $_TERRAME_EXECUTION_DIR
+# Copying TerraME test and config file to Test folder
+cp $_TERRAME_GIT_DIR/jenkins/all/*.lua $_TERRAME_TEST_DIR
+# Copying TerraME TerraLib compilation scripts to TerraLib solution folder
+cp $_TERRAME_GIT_DIR/build/scripts/linux/terralib-conf.* .
+# Copying TerraME compilation scripts to TerraME Solution folder
+cp $_TERRAME_GIT_DIR/build/scripts/linux/terrame-conf.* $_TERRAME_BUILD_BASE/solution
+
+# Compile TerraLib
+./terralib-conf.sh
+
+# Returns a TerraLib compilation execution code in order to Jenkins be able to set build status
+exit $?

--- a/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-terralib-build-linux-ubuntu-14.04.sh
@@ -40,7 +40,6 @@
 #
 ## USAGE:
 ## ./terrame-terralib-build-linux-ubuntu-14.04.sh
-##
 #
 
 # Constants
@@ -57,16 +56,16 @@ if [ ! -z "$ghprbActualCommit" ]; then
   cd $_TERRAME_GIT_DIR
   git init
   git config remote.origin.url https://github.com/terrame/terrame.git
-  git fetch --tags --progress https://github.com/TerraME/terrame.git +refs/pull/*:refs/remotes/origin/pr/* 2> /dev/null
-  git checkout -f $ghprbActualCommit
+  git fetch --tags --progress https://github.com/TerraME/terrame.git +refs/pull/*:refs/remotes/origin/pr/* --quiet
+  git checkout -f $ghprbActualCommit --quiet
   cd -
 else
   # Just clone
-  git clone https://github.com/raphaelrpl/terrame.git -b jenkins $_TERRAME_GIT_DIR
+  git clone https://github.com/terrame/terrame.git -b jenkins $_TERRAME_GIT_DIR --quiet
 fi
 
 echo "### TerraLib ###"
-git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git $_TERRALIB_GIT_DIR
+git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git $_TERRALIB_GIT_DIR --quiet
 
 # Creating TerraME Test folders and TerraLib solution
 mkdir $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR $_TERRALIB_BUILD_BASE/solution $_TERRAME_BUILD_BASE/solution

--- a/jenkins/linux/terrame-test-execution-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-test-execution-linux-ubuntu-14.04.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME test execution.
+#
+## USAGE:
+## ./terrame-test-execution-linux-ubuntu-14.04.sh
+#
+
+# Exporting enviroment variables
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+export LD_LIBRARY_PATH=$TME_PATH
+
+# Copying TerraME configuration
+cd $_TERRAME_EXECUTION_DIR
+
+terrame -version
+terrame -color run.lua 2> /dev/null
+RESULT=$?
+
+tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/linux/terrame-test-execution-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-test-execution-linux-ubuntu-14.04.sh
@@ -41,7 +41,7 @@ terrame -version
 terrame -color run.lua 2> /dev/null
 RESULT=$?
 
-tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+tar -czf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
 rm -rf .terrame*
 
 exit $RESULT

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -64,7 +64,7 @@ if [ "$1" != "" ] && [ "$1" != "base" ]; then
 
   if [ ! -z "$ghprbActualCommit" ]; then
     # Temp code to ensure unittest terralib does not take too long to execute. Only CI trigger
-    echo directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"} > test.lua
+    echo 'directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"}' >> test.lua
   fi
 fi
 

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME functional test of any package. For TerraME purporses, "base" and "terralib" internal packages. 
+## It may be useful for TerraME external packages.
+#
+## USAGE:
+## ./terrame-unittest-linux-ubuntu-14.04.sh PACKAGE_NAME
+#
+## WHERE:
+## PACKAGE_NAME - Represents a name of TerraME package to execute
+#
+
+# Exporting enviroment variables
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+export LD_LIBRARY_PATH=$TME_PATH
+
+cd $_TERRAME_TEST_DIR
+
+terrame -version
+
+TERRAME_COMMANDS=""
+# Extra commands if package is terralib
+if [ "$1" != "" ] && [ "$1" != "base" ]; then
+  TERRAME_COMMANDS="-package $1"
+fi
+
+# Executing unittest
+terrame -color $TERRAME_COMMANDS -test test.lua 2> /dev/null
+RESULT=$?
+
+# Compressing Log
+tar -czf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+
+# Cleaning up
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -42,6 +42,21 @@ cd $_TERRAME_TEST_DIR
 
 terrame -version
 
+# You may use $ghprbActualCommit for handling if job has triggered by CI event or daily timer.
+# In this way, if you need a specific configuration for CI execution, use this flag
+#
+# if [ -z "$ghprbActualCommit" ]; then
+  # Daily execution config
+
+#  if [ "$1" == "terralib" ]; then
+#    echo "myconfig" > test.lua
+#  else
+#    echo "myconfig2" > test.lua
+#  fi
+# else
+#  # CI execution config
+# fi
+
 TERRAME_COMMANDS=""
 # Extra commands if package is terralib
 if [ "$1" != "" ] && [ "$1" != "base" ]; then

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -61,11 +61,10 @@ TERRAME_COMMANDS=""
 # Extra commands if package is terralib
 if [ "$1" != "" ] && [ "$1" != "base" ]; then
   TERRAME_COMMANDS="-package $1"
-
-  if [ ! -z "$ghprbActualCommit" ]; then
-    # Temp code to ensure unittest terralib does not take too long to execute. Only CI trigger
-    echo -e '\ndirectory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"}' >> test.lua
-  fi
+  # if [ ! -z "$ghprbActualCommit" ]; then
+  #   # Temp code to ensure unittest terralib does not take too long to execute. Only CI trigger
+  #   echo -e '\ndirectory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"}' >> test.lua
+  # fi
 fi
 
 # Executing unittest

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -64,7 +64,7 @@ if [ "$1" != "" ] && [ "$1" != "base" ]; then
 
   if [ ! -z "$ghprbActualCommit" ]; then
     # Temp code to ensure unittest terralib does not take too long to execute. Only CI trigger
-    echo 'directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"}' >> test.lua
+    echo -e '\ndirectory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"}' >> test.lua
   fi
 fi
 

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -61,6 +61,9 @@ TERRAME_COMMANDS=""
 # Extra commands if package is terralib
 if [ "$1" != "" ] && [ "$1" != "base" ]; then
   TERRAME_COMMANDS="-package $1"
+
+  # Temp code to ensure unittest terralib does not take too long to execute
+  echo directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"} > test.lua
 fi
 
 # Executing unittest
@@ -68,7 +71,7 @@ terrame -color $TERRAME_COMMANDS -test test.lua 2> /dev/null
 RESULT=$?
 
 # Compressing Log
-tar -czf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+tar -czf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
 
 # Cleaning up
 rm -rf .terrame*

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -73,7 +73,9 @@ terrame -color $TERRAME_COMMANDS -test test.lua 2> /dev/null
 RESULT=$?
 
 # Compressing Log
-tar -czf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+LOG_NAME="build-daily-linux-$BUILD_NUMBER.tar.gz"
+echo "Compressing $WORKSPACE/$LOG_NAME"
+tar -czf $WORKSPACE/$LOG_NAME .terrame*
 
 # Cleaning up
 rm -rf .terrame*

--- a/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
+++ b/jenkins/linux/terrame-unittest-linux-ubuntu-14.04.sh
@@ -62,8 +62,10 @@ TERRAME_COMMANDS=""
 if [ "$1" != "" ] && [ "$1" != "base" ]; then
   TERRAME_COMMANDS="-package $1"
 
-  # Temp code to ensure unittest terralib does not take too long to execute
-  echo directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"} > test.lua
+  if [ ! -z "$ghprbActualCommit" ]; then
+    # Temp code to ensure unittest terralib does not take too long to execute. Only CI trigger
+    echo directory = {"functional", "shapefile", "postgis", "tif", "geojson", "asc", "wms", "nc"} > test.lua
+  fi
 fi
 
 # Executing unittest

--- a/jenkins/mac/terrame-3rdparty-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-3rdparty-mac-el-capitan.sh
@@ -1,0 +1,122 @@
+#!/bin/bash -l
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs TerraME TerraLib compilation on MacOSX El Capitan system
+#
+
+if [ -z "$_TERRALIB_TARGET_3RDPARTY_DIR" ]; then
+  export _TERRALIB_TARGET_3RDPARTY_DIR="$HOME/MyDevel/terrame/daily/terralib/3rdparty/5.2"
+fi
+
+if [ -z "$_TERRAME_TARGET_3RDPARTY_DIR" ]; then
+  export _TERRAME_TARGET_3RDPARTY_DIR="$HOME/MyDevel/terrame/daily/terrame/3rdparty"
+fi
+
+_TERRALIB_BRANCH="release-5.2"
+export _TERRALIB_3RDPARTY_NAME="terralib-3rdparty-macosx-el-capitan.tar.gz"
+export _TERRALIB_TARGET_URL="http://www.dpi.inpe.br/terralib5-devel/3rdparty/src/$_TERRALIB_3RDPARTY_NAME"
+
+export PATH=$PATH:$HOME/Qt5.6.0/5.6/clang_64/bin
+
+#
+# Valid parameter val or abort script
+#
+function valid_operation()
+{
+  if [ $1 -ne 0 ]; then
+    echo $2
+    echo ""
+    exit $1
+  else
+    echo "done."
+  fi
+}
+
+
+echo ""
+echo "#### TerraME Dependencies Compilation on MacOSX El Capitan ####"
+echo ""
+
+echo -ne "Cleaning up old builds ... "
+rm -rf $_TERRALIB_TARGET_3RDPARTY_DIR $_TERRAME_TARGET_3RDPARTY_DIR
+mkdir -p $_TERRALIB_TARGET_3RDPARTY_DIR $_TERRAME_TARGET_3RDPARTY_DIR
+cd $_TERRALIB_TARGET_3RDPARTY_DIR
+echo "done."
+
+echo ""
+
+echo -ne "Downloading TerraLib 3rdparty ... "
+curl -L -O $_TERRALIB_TARGET_URL --silent
+valid_operation $? "Error. Check $_TERRALIB_TARGET_URL"
+
+echo -ne "Downloading TerraLib ... "
+git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git --quiet
+valid_operation $? "Error. Could not clone TerraLib $_TERRALIB_BRANCH" terralib
+
+echo -ne "Downloading TerraME ... "
+git clone https://github.com/TerraME/terrame.git terrame --quiet
+valid_operation $? "Error: Could not download TerraME"
+
+# Configuring TerraLib 3rdparty compilation
+cp terralib/install/install-3rdparty-macosx-el-capitan.sh .
+
+# Configuring TerraME dependencies compilation
+cp terrame/build/scripts/mac/terrame-deps-conf.sh $_TERRAME_TARGET_3RDPARTY_DIR
+
+echo -ne "Compiling TerraLib dependencies ... "
+TERRALIB_DEPENDENCIES_DIR="$_TERRALIB_TARGET_3RDPARTY_DIR" ./install-3rdparty-macosx-el-capitan.sh
+valid_operation $? "Error: Could not finish TerraLib 3rdparty compilation"
+
+echo ""
+echo ""
+
+cd $_TERRAME_TARGET_3RDPARTY_DIR
+
+echo -ne "Downloading Protobuf ... "
+curl -L -O https://github.com/google/protobuf/releases/download/v3.1.0/protobuf-cpp-3.1.0.tar.gz --silent
+valid_operation $? "Error. Could not download 3rdparty"
+
+echo -ne "Downloading Luacheck ... "
+curl -L -O https://github.com/mpeterv/luacheck/archive/0.17.0.tar.gz --silent
+valid_operation $? "Error: Could not download LuaCheck"
+
+echo ""
+echo -ne "Preparing to compilation ... "
+tar zxf protobuf-cpp-3.1.0.tar.gz
+valid_operation $? "Error: Could not extract protobuff"
+mv protobuf-3.1.0 protobuf
+valid_operation $? "Error: Could find 'protobuf' folder inside compressed protobuf"  
+tar zxf 0.17.0.tar.gz
+valid_operation $? "Error: Could not extract Luacheck" 
+mv luacheck* luacheck
+valid_operation $? "Error: Could find luacheck inside luacheck compressed file" 
+
+echo -ne "Compiling TerraME dependencies ... "
+./terrame-deps-conf.sh
+valid_operation $? "Error: Could not finish TerraME 3rdparty compilation."
+
+echo ""
+echo "Finished"
+echo ""

--- a/jenkins/mac/terrame-build-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-build-mac-el-capitan.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -l
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs TerraME compilation. It does not create installer or even build as bundle.
+##
+#
+## USAGE:
+## ./terrame-build-linux-ubuntu-14.04.sh
+##
+#
+
+cd $_TERRAME_BUILD_BASE/solution
+ 
+# Turning OFF installer flags
+export _TERRAME_CREATE_INSTALLER="OFF"
+export _TERRAME_BUILD_AS_BUNDLE="ON"
+
+# Executing TerraME build script
+./terrame-conf.sh
+
+exit $?

--- a/jenkins/mac/terrame-doc-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-doc-mac-el-capitan.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -l
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME doc generation of a package.
+##
+#
+## USAGE:
+## ./terrame-doc-mac-el-capitan.sh PACKAGE_NAME
+##
+## WHERE:
+## PACKAGE_NAME - Represents a name of TerraME package to execute
+##
+#
+
+# Exporting context
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+
+cd $_TERRAME_TEST_DIR
+
+TERRAME_COMMANDS=""
+terrame -version
+if [ "$1" != "" ] && [ "$1" != "base" ]; then
+  TERRAME_COMMANDS="-package $1"
+  terrame -color $TERRAME_COMMANDS -projects 2>/dev/null
+fi
+
+# Execute TerraME doc generation
+terrame -color $TERRAME_COMMANDS -doc 2> /dev/null
+# Retrieve TerraME exit code
+exit $?

--- a/jenkins/mac/terrame-installer-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-installer-mac-el-capitan.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME Installer generation on MacOSX environment
+#
+## USAGE:
+## ./terrame-installer-linux-ubuntu-14.04.sh
+#
+
+export _TERRAME_CREATE_INSTALLER="ON"
+export _TERRAME_BUILD_AS_BUNDLE="ON"
+
+cd $_TERRAME_OUT_DIR/..
+
+cp -rap $_TERRAME_INSTALL_PATH/bin/packages/base/doc $_TERRAME_GIT_DIR/packages/base/doc
+cp -rap $_TERRAME_INSTALL_PATH/bin/packages/terralib/doc $_TERRAME_GIT_DIR/packages/terralib/doc
+
+# Removing old builds
+rm -rf $_TERRAME_INSTALL_PATH $_TERRAME_OUT_DIR
+
+# Executing TerraME build script
+./terrame-conf.sh
+
+exit $?

--- a/jenkins/mac/terrame-repository-test-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-repository-test-mac-el-capitan.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME Repository Tests.
+##
+#
+## USAGE:
+## ./terrame-repository-test-m,ac-el-capitan.sh
+#
+
+export TME_PATH="$_TERRAME_INSTALL_PATH/bin"
+export PATH=$PATH:$TME_PATH
+
+cd $_TERRAME_REPOSITORY_DIR
+
+terrame -version
+terrame -color test.lua 2> /dev/null
+
+RESULT=$?
+
+tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/mac/terrame-repository-test-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-repository-test-mac-el-capitan.sh
@@ -40,7 +40,7 @@ terrame -color test.lua 2> /dev/null
 
 RESULT=$?
 
-tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+tar -czvf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
 rm -rf .terrame*
 
 exit $RESULT

--- a/jenkins/mac/terrame-terralib-build-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-terralib-build-mac-el-capitan.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It prepares a entire TerraME build process. Firstly, it prepares environment, cloning both TerraME and TerraLib.
+## After that, It copies required scripts to respective folders. Once done, it compiles TerraLib.
+## Jenkins will export variables defined in jenkins/linux for respective build type. If PR events, it uses VARIABLES-ci.
+## Otherwise, use VARIABLES-daily
+##
+#
+## VARIABLES:
+## _TERRAME_GIT_DIR - Path to TerraME clone
+## _TERRALIB_GIT_DIR - Path to TerraLib clone
+## _TERRAME_DEPENDS_DIR - Path to TerraME dependencies
+## _TERRALIB_INSTALL_PATH - Path to TerraLib Installation
+## _TERRALIB_3RDPARTY_DIR - Path to TerraLib dependencies
+## _TERRAME_TEST_DIR - Path where TerraME tests will execute.
+## _TERRAME_REPOSITORY_DIR - Path where TerraME repository test will execute
+## _TERRAME_EXECUTION_DIR - Path where TerraME test execution will run
+## ghprbActualCommit (Injected by Jenkins on GitHub Pull Requests) (Optional) - Git Commit hash
+## sha1 (Injected by Jenkins on GitHub Pull Requests) (Optional) - Represents refspec Pull Request (origin/PR_ID/head)
+#
+## USAGE:
+## ./terrame-terralib-build-mac-el-capitan.sh
+##
+#
+
+# Constants
+_TERRALIB_BRANCH=release-5.2
+
+# Removing TerraLib Mod Binding Lua in order to re-generate folder if there is
+rm -rf $_TERRALIB_OUT_DIR/terralib_mod_binding_lua $_TERRALIB_INSTALL_PATH $_TERRAME_GIT_DIR $_TERRALIB_GIT_DIR $_TERRAME_BUILD_BASE/solution
+rm -rf $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR
+
+echo "### TerraME ###"
+git clone https://github.com/raphaelrpl/terrame.git -b jenkins $_TERRAME_GIT_DIR
+
+echo "### TerraLib ###"
+git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git $_TERRALIB_GIT_DIR
+
+# Creating TerraME Test folders and TerraLib solution
+mkdir $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR $_TERRALIB_BUILD_BASE/solution $_TERRAME_BUILD_BASE/solution
+
+cd $_TERRALIB_BUILD_BASE/solution
+
+# Copying TerraME Git Repository to Test Repository Folder
+cp -r $_TERRAME_GIT_DIR/repository/* $_TERRAME_REPOSITORY_DIR
+# Copying TerraME Git Test Execution to Test Execution Folder
+cp -r $_TERRAME_GIT_DIR/test/* $_TERRAME_EXECUTION_DIR
+# Copying TerraME test and config file to Test folder
+cp $_TERRAME_GIT_DIR/jenkins/all/*.lua $_TERRAME_TEST_DIR
+# Copying TerraME TerraLib compilation scripts to TerraLib solution folder
+cp $_TERRAME_GIT_DIR/build/scripts/mac/terralib-conf.* .
+# Copying TerraME compilation scripts to TerraME Solution folder
+cp $_TERRAME_GIT_DIR/build/scripts/mac/terrame-conf.* $_TERRAME_BUILD_BASE/solution
+
+# Compile TerraLib
+./terralib-conf.sh
+
+# Returns a TerraLib compilation execution code in order to Jenkins be able to set build status
+exit $?

--- a/jenkins/mac/terrame-terralib-build-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-terralib-build-mac-el-capitan.sh
@@ -54,7 +54,7 @@ rm -rf $_TERRALIB_OUT_DIR/terralib_mod_binding_lua $_TERRALIB_INSTALL_PATH $_TER
 rm -rf $_TERRAME_REPOSITORY_DIR $_TERRAME_TEST_DIR $_TERRAME_EXECUTION_DIR
 
 echo "### TerraME ###"
-git clone https://github.com/raphaelrpl/terrame.git -b jenkins $_TERRAME_GIT_DIR
+git clone https://github.com/terrame/terrame.git $_TERRAME_GIT_DIR
 
 echo "### TerraLib ###"
 git clone -b $_TERRALIB_BRANCH https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git $_TERRALIB_GIT_DIR

--- a/jenkins/mac/terrame-test-execution-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-test-execution-mac-el-capitan.sh
@@ -40,7 +40,7 @@ terrame -version
 terrame -color run.lua 2> /dev/null
 RESULT=$?
 
-tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+tar -czvf $WORKSPACE/build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
 rm -rf .terrame*
 
 exit $RESULT

--- a/jenkins/mac/terrame-test-execution-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-test-execution-mac-el-capitan.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME test execution.
+#
+## USAGE:
+## ./terrame-test-execution-mac-el-capitan.sh
+#
+
+# Exporting enviroment variables
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+
+# Copying TerraME configuration
+cd $_TERRAME_EXECUTION_DIR
+
+terrame -version
+terrame -color run.lua 2> /dev/null
+RESULT=$?
+
+tar -czvf build-daily-linux-$BUILD_NUMBER.tar.gz .terrame*
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/mac/terrame-unittest-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-unittest-mac-el-capitan.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#
+# TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+# Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+#
+# This code is part of the TerraME framework.
+# This framework is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+# The authors reassure the license terms regarding the warranties.
+# They specifically disclaim any warranties, including, but not limited to,
+# the implied warranties of merchantability and fitness for a particular purpose.
+# The framework provided hereunder is on an "as is" basis, and the authors have no
+# obligation to provide maintenance, support, updates, enhancements, or modifications.
+# In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+# indirect, special, incidental, or consequential damages arising out of the use
+# of this software and its documentation.
+
+# 
+## It performs a TerraME functional test package
+#
+## USAGE:
+## ./terrame-unittest-linux-mac-el-capitan.sh PACKAGE_NAME
+##
+## WHERE:
+## PACKAGE_NAME - Represents a name of TerraME package to execute
+##
+#
+
+# Exporting enviroment variables
+export TME_PATH=$_TERRAME_INSTALL_PATH/bin
+export PATH=$PATH:$TME_PATH
+
+cd $_TERRAME_TEST_DIR
+
+terrame -version
+
+TERRAME_COMMANDS=""
+terrame -version
+# Extra commands if package is terralib
+if [ "$1" != "" ] && [ "$1" != "base" ]; then
+  TERRAME_COMMANDS="-package $1"
+fi
+
+# Executing unittest
+terrame -color $TERRAME_COMMANDS -test test.lua 2> /dev/null
+RESULT=$?
+
+# Compressing Log
+tar -czvf build-daily-mac-$BUILD_NUMBER.tar.gz .terrame*
+
+# Cleaning up
+rm -rf .terrame*
+
+exit $RESULT

--- a/jenkins/mac/terrame-unittest-mac-el-capitan.sh
+++ b/jenkins/mac/terrame-unittest-mac-el-capitan.sh
@@ -53,7 +53,7 @@ terrame -color $TERRAME_COMMANDS -test test.lua 2> /dev/null
 RESULT=$?
 
 # Compressing Log
-tar -czvf build-daily-mac-$BUILD_NUMBER.tar.gz .terrame*
+tar -czvf $WORKSPACE/build-daily-mac-$BUILD_NUMBER.tar.gz .terrame*
 
 # Cleaning up
 rm -rf .terrame*

--- a/jenkins/win/terrame-3rdparty-windows-10.bat
+++ b/jenkins/win/terrame-3rdparty-windows-10.bat
@@ -1,0 +1,121 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs TerraME compilation. It does not create installer or even build as bundle.'
+::
+::
+:: USAGE:
+:: terrame-build-windows-10.bat
+::
+
+:: Turn off system messages
+
+@echo off
+
+set "_CURL_DIR=C:\curl"
+set "PATH=%PATH%;%_CURL_DIR%"
+
+echo ""
+echo "TerraME Dependencies compilation on Windows 10"
+echo ""
+
+set "_TERRALIB_3RDPARTY_NAME=terralib5-3rdparty-msvc12.zip"
+set "_TERRALIB_TARGET_URL=http://www.dpi.inpe.br/terralib5-devel/3rdparty/src/$_TERRALIB_3RDPARTY_NAME"
+set "_TERRAME_3RDPARTY_DIR=C:\MyDevel\terrame\daily-build\terrame\3rdparty"
+set "_BUILD_PATH=C:\tme-3rdparty"
+:: TerraLib 3rdparty variables
+set "TERRALIB_X64=1"
+set "_config=x64"
+set "QMAKE_FILEPATH=C:\Qt\5.6\msvc2013_64\bin"
+set "TERRALIB_DEPENDENCIES_DIR=C:\MyDevel\terrame\daily-build\terralib\3rdparty\5.2"
+set "TERRALIB5_CODEBASE_PATH=%CD%\terralib"
+set "VCVARS_FILEPATH=%PROGRAMFILES(x86)%\Microsoft Visual Studio 12.0\VC"
+
+:: Configuring VStudio
+echo | set /p="Configuring visual studio... "<nul
+
+call "%VCVARS_FILEPATH%"\vcvarsall.bat %_config%
+
+echo done.
+
+echo | set /p="Cleaning up old builds ... "<nul
+rmdir %_BUILD_PATH% /s /q >nul 2>nul
+rmdir %TERRALIB_DEPENDENCIES_DIR% /s /q >nul 2>nul
+rmdir %TERRALIB5_CODEBASE_PATH% /s /q >nul 2>nul
+rmdir %_TERRAME_3RDPARTY_DIR% /s /q >nul 2>nul
+mkdir %TERRALIB5_CODEBASE_PATH% /s /q >nul 2>nul
+mkdir %_TERRAME_3RDPARTY_DIR% /s /q >nul 2>nul
+echo done.
+
+:: Downloading TerraLib
+echo | set /p="Downloading TerraLib ... "<nul
+git clone -b release-5.2 https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git %TERRALIB5_CODEBASE_PATH% --quiet
+echo done.
+:: Downloading TerraME
+echo | set /p="Downloading TerraME ... "<nul
+git clone https://github.com/TerraME/terrame.git terrame --quiet
+echo done.
+
+echo | set /p="Downloading TerraLib 3rdparty ... "<nul
+curl -L -s -O %_TERRALIB_TARGET_3RDPARTY_DIR%
+echo done.
+
+copy terrame\build\scripts\win\terrame-deps-conf.bat %_TERRAME_3RDPARTY_DIR%
+:: Extracting TerraLib 3rdparty and moving short-named directory. It prevents Windows directory and filename limitation (255 chars)
+"C:\Program Files\7-Zip\7z.exe" x terralib-3rdparty-msvc12.zip -y
+mv terralib-3rdparty-msvc12 %_BUILD_PATH%
+cd %_BUILD_PATH%\terralib-3rdparty-msvc12
+
+:: Compile TerraLib 3rdparty Dependencies
+start /wait %TERRALIB5_CODEBASE_PATH%\install\install-3rdparty.bat
+
+cd %_TERRAME_3RDPARTY_DIR%
+
+echo | set /p="Downloading Protobuf ... "<nul
+curl -O -J -L https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.zip --silent
+echo done.
+"C:\Program Files\7-Zip\7z.exe" x protobuf-2.6.1.zip -y
+rename protobuf-2.6.1 protobuf
+
+echo | set /p="Downloading Luacheck ... "<nul
+curl -L -s -O https://github.com/mpeterv/luacheck/archive/0.17.0.zip
+echo done.
+"C:\Program Files\7-Zip\7z.exe" x 0.17.0.zip -y
+rename luacheck-0.17.0 luacheck
+
+copy %WORKSPACE%\build\scripts\win\terrame-deps-conf.bat .
+:: Installing Luacheck
+call terrame-deps-conf.bat
+
+:: Compiling Protobuf
+cd %_TERRAME_3RDPARTY_DIR%\protobuf\vsprojects
+msbuild /m protobuf.sln /target:libprotobuf /p:Configuration=Release /p:Platform=x64 /maxcpucount:4
+msbuild /m protobuf.sln /target:libprotobuf-lite /p:Configuration=Release /p:Platform=x64 /maxcpucount:4
+msbuild /m protobuf.sln /target:libprotoc /p:Configuration=Release /p:Platform=x64 /maxcpucount:4
+msbuild /m protobuf.sln /target:protoc /p:Configuration=Release /p:Platform=x64 /maxcpucount:4
+:: Extract Protobuf includes
+call extract_includes.bat
+:: Copying Protobuf includes
+xcopy include %_TERRAME_3RDPARTY_DIR%\install\include /i /h /e /y
+
+exit %ERRORLEVEL%

--- a/jenkins/win/terrame-build-windows-10.bat
+++ b/jenkins/win/terrame-build-windows-10.bat
@@ -1,0 +1,41 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs TerraME compilation. It does not create installer or even build as bundle.'
+::
+::
+:: USAGE:
+:: terrame-build-windows-10.bat
+::
+::
+
+cd %_TERRAME_BUILD_BASE%\solution
+ 
+:: Turning OFF installer flags
+set "_TERRAME_CREATE_INSTALLER=OFF"
+set "_TERRAME_BUILD_AS_BUNDLE=ON"
+
+:: Executing TerraME build script
+terrame-conf.bat
+
+exit %ERRORLEVEL%

--- a/jenkins/win/terrame-doc-windows-10.bat
+++ b/jenkins/win/terrame-doc-windows-10.bat
@@ -1,0 +1,47 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+::
+:: It generates a TerraME doc for a package
+::
+:: USAGE:
+:: terrame-doc-windows-10.bat PACKAGE_NAME
+::
+:: PACKAGE_NAME - Represents a name of TerraME package to execute
+::
+
+:: setting context
+set "TME_PATH=%_TERRAME_INSTALL_PATH%\bin"
+set "PATH=%PATH%;%TME_PATH%"
+
+cd %_TERRAME_TEST_DIR%
+
+terrame -version
+:: Extra commands if package is terralib
+IF NOT "%1" == "" (
+  terrame -color -package terralib -projects
+  terrame -color -package terralib -doc
+) ELSE (
+  terrame -color -doc
+)
+
+:: Retrieve TerraME exit code
+exit %ERRORLEVEL%

--- a/jenkins/win/terrame-installer-windows-10.bat
+++ b/jenkins/win/terrame-installer-windows-10.bat
@@ -1,0 +1,49 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs a TerraME Installer generation
+::
+:: USAGE:
+:: terrame-installer-windows-10.bat
+::
+
+set "_TERRAME_CREATE_INSTALLER=ON"
+set "_TERRAME_BUILD_AS_BUNDLE=ON"
+
+cd %_TERRAME_OUT_DIR%\..
+
+:: Copying generated logs to GIT dir
+xcopy %_TERRAME_INSTALL_PATH%\bin\packages\base\doc %_TERRAME_GIT_DIR%\packages\base\doc /i /h /e /y
+xcopy %_TERRAME_INSTALL_PATH%\bin\packages\terralib\doc %_TERRAME_GIT_DIR%\packages\terralib\doc /i /h /e /y
+
+:: Removing build and install in order to generate again
+rmdir %_TERRAME_INSTALL_PATH% /s /q
+rmdir %_TERRAME_OUT_DIR% /s /q
+
+:: Executing TerraME build script
+call terrame-conf.bat
+
+:: Packing
+cpack -G NSIS -C Release --config CPackConfig.cmake
+
+exit %ERRORLEVEL%

--- a/jenkins/win/terrame-repository-test-windows-10.bat
+++ b/jenkins/win/terrame-repository-test-windows-10.bat
@@ -1,0 +1,45 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs a TerraME Repository Tests.
+::
+::
+:: USAGE:
+:: terrame-repository-test-windows-10.bat
+::
+
+set "TME_PATH=%_TERRAME_INSTALL_PATH%\bin"
+set "PATH=%PATH%;%TME_PATH%
+
+cd %_TERRAME_REPOSITORY_DIR%
+
+terrame -version
+terrame -color test.lua
+
+set "RESULT=%ERRORLEVEL%"
+
+"C:\Program Files\7-Zip\7z.exe" a -tzip "%WORKSPACE%\build-win-%BUILD_NUMBER%.zip" .terrame*
+
+for /d %%G in (".terrame*") do rd /s /q "%%~G"
+
+exit %RESULT%

--- a/jenkins/win/terrame-terralib-build-windows-10.bat
+++ b/jenkins/win/terrame-terralib-build-windows-10.bat
@@ -1,0 +1,79 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It prepares a entire TerraME build process. Firstly, it prepares environment, cloning both TerraME and TerraLib.
+:: After that, It copies required scripts to respective folders. Once done, it compiles TerraLib.
+::
+:: VARIABLES:
+:: _TERRAME_GIT_DIR - Path to TerraME clone
+:: _TERRALIB_GIT_DIR - Path to TerraLib clone
+:: _TERRAME_DEPENDS_DIR - Path to TerraME dependencies
+:: _TERRALIB_INSTALL_PATH - Path to TerraLib Installation
+:: _TERRALIB_3RDPARTY_DIR - Path to TerraLib dependencies
+:: _TERRAME_TEST_DIR - Path where TerraME tests will execute.
+:: _TERRAME_REPOSITORY_DIR - Path where TerraME repository test will execute
+:: _TERRAME_EXECUTION_DIR - Path where TerraME test execution will run
+::
+:: USAGE:
+:: terrame-terralib-build-windows-10.bat
+::
+
+set "_TERRALIB_BRANCH=release-5.2"
+
+:: Removing TerraLib Mod Binding Lua in order to re-generate folder if there is
+rmdir %_TERRALIB_GIT_DIR% /s /q
+rmdir %_TERRALIB_INSTALL_PATH% /s /q
+rmdir %_TERRALIB_OUT_DIR%\terralib_mod_binding_lua /s /q
+rmdir %_TERRAME_GIT_DIR% /s /q
+rmdir %_TERRAME_BUILD_BASE%\solution /s /q
+rmdir %_TERRAME_EXECUTION_DIR% /s /q
+rmdir %_TERRAME_REPOSITORY_DIR% /s /q
+rmdir %_TERRAME_TEST_DIR% /s /q
+
+echo ":::: TerraME ::::"
+git clone https://github.com/raphaelrpl/terrame.git -b jenkins %_TERRAME_GIT_DIR% --quiet
+
+echo ":::: TerraLib ::::"
+git clone -b %_TERRALIB_BRANCH% https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git %_TERRALIB_GIT_DIR% --quiet
+
+:: Creating TerraME Test folders and TerraLib solution
+mkdir %_TERRAME_REPOSITORY_DIR% %_TERRAME_TEST_DIR% %_TERRAME_EXECUTION_DIR% %_TERRALIB_BUILD_BASE%\solution %_TERRAME_BUILD_BASE%\solution
+
+cd %_TERRALIB_BUILD_BASE%\solution
+
+:: Copying TerraME Git Repository to Test Repository Folder
+xcopy %_TERRAME_GIT_DIR%\repository\* %_TERRAME_REPOSITORY_DIR% /i /h /e /y
+:: Copying TerraME Git Test Execution to Test Execution Folder
+xcopy %_TERRAME_GIT_DIR%\test\* %_TERRAME_EXECUTION_DIR% /i /h /e /y
+:: Copying TerraME test and config file to Test folder
+xcopy %_TERRAME_GIT_DIR%\jenkins\all\*.lua %_TERRAME_TEST_DIR% /i /h /e /y
+:: Copying TerraME TerraLib compilation scripts to TerraLib solution folder
+xcopy %_TERRAME_GIT_DIR%\build\scripts\win\terralib-conf.* . /i /h /e /y
+:: Copying TerraME compilation scripts to TerraME Solution folder
+xcopy %_TERRAME_GIT_DIR%\build\scripts\win\terrame-conf.* %_TERRAME_BUILD_BASE%\solution /i /h /e /y
+
+:: Compile TerraLib
+terralib-conf.bat
+
+:: Returns a TerraLib compilation execution code in order to Jenkins be able to set build status
+exit %ERRORLEVEL%

--- a/jenkins/win/terrame-terralib-build-windows-10.bat
+++ b/jenkins/win/terrame-terralib-build-windows-10.bat
@@ -51,7 +51,7 @@ rmdir %_TERRAME_REPOSITORY_DIR% /s /q
 rmdir %_TERRAME_TEST_DIR% /s /q
 
 echo ":::: TerraME ::::"
-git clone https://github.com/raphaelrpl/terrame.git -b jenkins %_TERRAME_GIT_DIR% --quiet
+git clone https://github.com/terrame/terrame.git %_TERRAME_GIT_DIR% --quiet
 
 echo ":::: TerraLib ::::"
 git clone -b %_TERRALIB_BRANCH% https://gitlab.dpi.inpe.br/rodrigo.avancini/terralib.git %_TERRALIB_GIT_DIR% --quiet

--- a/jenkins/win/terrame-test-execution-windows-10.bat
+++ b/jenkins/win/terrame-test-execution-windows-10.bat
@@ -1,0 +1,45 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs a TerraME test execution.
+::
+:: USAGE:
+:: terrame-test-execution-windows-10.bat
+::
+
+:: Exporting enviroment variables
+set "TME_PATH=%_TERRAME_INSTALL_PATH%\bin"
+set "PATH=%PATH%;%TME_PATH%"
+
+:: Copying TerraME configuration
+cd %_TERRAME_EXECUTION_DIR%
+
+terrame -version
+terrame -color run.lua
+set "RESULT=%ERRORLEVEL%"
+
+"C:\Program Files\7-Zip\7z.exe" a -tzip "%WORKSPACE%\build-daily-win-%BUILD_NUMBER%.zip" .terrame*
+
+for /d %%G in (".terrame*") do rd /s /q "%%~G"
+
+exit %RESULT%

--- a/jenkins/win/terrame-unittest-windows-10.bat
+++ b/jenkins/win/terrame-unittest-windows-10.bat
@@ -1,0 +1,56 @@
+::
+:: TerraME - a software platform for multiple scale spatially-explicit dynamic modeling.
+:: Copyright (C) 2001-2017 INPE and TerraLAB/UFOP -- www.terrame.org
+::
+:: This code is part of the TerraME framework.
+:: This framework is free software; you can redistribute it and/or
+:: modify it under the terms of the GNU Lesser General Public
+:: License as published by the Free Software Foundation; either
+:: version 2.1 of the License, or (at your option) any later version.
+::
+:: You should have received a copy of the GNU Lesser General Public
+:: License along with this library.
+::
+:: The authors reassure the license terms regarding the warranties.
+:: They specifically disclaim any warranties, including, but not limited to,
+:: the implied warranties of merchantability and fitness for a particular purpose.
+:: The framework provided hereunder is on an "as is" basis, and the authors have no
+:: obligation to provide maintenance, support, updates, enhancements, or modifications.
+:: In no event shall INPE and TerraLAB / UFOP be held liable to any party for direct,
+:: indirect, special, incidental, or consequential damages arising out of the use
+:: of this software and its documentation.
+
+:: 
+:: It performs a TerraME functional test of any package. For TerraME purporses, "base" and "terralib" internal packages. 
+:: It may be useful for TerraME external packages.
+::
+:: USAGE:
+:: terrame-unittest-windows-10.bat PACKAGE_NAME
+::
+:: WHERE:
+:: PACKAGE_NAME - Represents a name of TerraME package to execute
+::
+
+:: Exporting enviroment variables
+set "TME_PATH=%_TERRAME_INSTALL_PATH%\bin"
+set "PATH=%PATH%;%TME_PATH%"
+
+cd %_TERRAME_TEST_DIR%
+
+terrame -version
+
+IF NOT "%1" == "" (
+  terrame -color -package terralib -test test.lua
+) ELSE (
+  terrame -color -test test.lua
+)
+
+set "RESULT=%ERRORLEVEL%"
+
+:: Compressing Log
+"C:\Program Files\7-Zip\7z.exe" a -tzip "%WORKSPACE%\build-win-%BUILD_NUMBER%.zip" .terrame*
+
+:: Cleaning up
+for /d %%G in (".terrame*") do rd /s /q "%%~G"
+
+exit %RESULT%


### PR DESCRIPTION
### Overview

This PR moves Jenkins scripts into TerraME repository. With these changes, the developers will be able to configure environment for CI events or even daily builds. The scripts were moved to `jenkins` folder with respective operation system.

- [x] #1496

#### Note

Jenkins job settings has changed to work with these changes. It may required to rebuild CI execution several times until working properly. After merged, we may trigger a daily jobs execution to ensure everything is working.