### PR TITLE
Fixing C++ method ceil() on Mac

### DIFF
--- a/src/observer/components/painter/painterThread.cpp
+++ b/src/observer/components/painter/painterThread.cpp
@@ -26,6 +26,7 @@ of this software and its documentation.
 #include <QtGui/QPainter>
 #include <QDebug>
 #include <time.h>
+#include <math.h>
 #include "terrameGlobals.h"
 
 #include "../legend/legendAttributes.h"


### PR DESCRIPTION
From #1931 